### PR TITLE
Format generated CSS with vp fmt

### DIFF
--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches: [main]
     paths:
-      - package/src/squircle.css
-      - package/src/merge.ts
-      - package/src/plugin.ts
+      - package/src/**
+      - package/scripts/generate-squircle-css.ts
+      - package/vite.config.ts
+      - scripts/sync-readme.sh
+      - vite.config.ts
 
 jobs:
   sync:

--- a/package/scripts/generate-squircle-css.ts
+++ b/package/scripts/generate-squircle-css.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -82,4 +83,5 @@ const distDir = join(__dirname, "..", "dist");
 mkdirSync(distDir, { recursive: true });
 const outPath = join(distDir, "squircle.css");
 writeFileSync(outPath, output);
+execFileSync("npx", ["vp", "fmt", outPath], { stdio: "inherit" });
 console.log(`Generated ${outPath}`);


### PR DESCRIPTION
## Summary
- Run `vp fmt` on the generated `squircle.css` before it lands in `dist/`, ensuring consistent formatting in the published package

## Test plan
- [x] `vp run sync-readme` completes successfully
- [x] `vp fmt --check dist/squircle.css` passes after build

https://claude.ai/code/session_0167amJ9Xuws2kzTEY1N5vEP