### PR TITLE
feat: add semantic-release dry-run to PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: voidzero-dev/setup-vp@v1
         with:
@@ -18,3 +23,7 @@ jobs:
       - run: vp install
 
       - run: vp run ready
+
+      - run: npx semantic-release --dry-run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `npx semantic-release --dry-run` step to CI workflow to verify the release pipeline on PRs before merge
- Uses `fetch-depth: 0` so semantic-release can access full git history and tags

## Test plan

- [x] CI workflow passes with dry-run step

🤖 Generated with [Claude Code](https://claude.com/claude-code)