### PR TITLE
feat: fix npm OIDC publishing by using @semantic-release/exec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,20 @@ jobs:
 
       - run: vp run @klinking/squircle#build
 
+      - name: Debug npm auth context
+        run: |
+          echo "=== npm config ==="
+          npm config list
+          echo "=== OIDC env vars ==="
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
+          echo "=== .npmrc files ==="
+          cat ~/.npmrc 2>/dev/null || echo "no ~/.npmrc"
+          cat .npmrc 2>/dev/null || echo "no ./.npmrc"
+          cat package/.npmrc 2>/dev/null || echo "no package/.npmrc"
+
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          DEBUG: "semantic-release:*,@semantic-release/npm:*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_IGNORE_SCRIPTS: true
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,20 +31,6 @@ jobs:
 
       - run: vp run @klinking/squircle#build
 
-      - name: Debug npm auth context
-        run: |
-          echo "=== npm config ==="
-          npm config list
-          echo "=== OIDC env vars ==="
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
-          echo "=== .npmrc files ==="
-          cat ~/.npmrc 2>/dev/null || echo "no ~/.npmrc"
-          cat .npmrc 2>/dev/null || echo "no ./.npmrc"
-          cat package/.npmrc 2>/dev/null || echo "no package/.npmrc"
-
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          DEBUG: "semantic-release:*,@semantic-release/npm:*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_IGNORE_SCRIPTS: true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,13 @@
       "@semantic-release/npm",
       {
         "pkgRoot": "package",
-        "provenance": true
+        "npmPublish": false
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "publishCmd": "npm publish package"
       }
     ],
     "@semantic-release/github"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepare": "vp config"
   },
   "devDependencies": {
+    "@semantic-release/exec": "catalog:",
     "@types/node": "catalog:",
     "conventional-changelog-conventionalcommits": "catalog:",
     "semantic-release": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@semantic-release/exec':
+      specifier: ^7
+      version: 7.1.0
     '@types/node':
       specifier: ^24
       version: 24.12.2
@@ -27,6 +30,9 @@ importers:
 
   .:
     devDependencies:
+      '@semantic-release/exec':
+        specifier: 'catalog:'
+        version: 7.1.0(semantic-release@25.0.3(typescript@6.0.2))
       '@types/node':
         specifier: 'catalog:'
         version: 24.12.2
@@ -1049,6 +1055,12 @@ packages:
     resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
     engines: {node: '>=18'}
 
+  '@semantic-release/exec@7.1.0':
+    resolution: {integrity: sha512-4ycZ2atgEUutspPZ2hxO6z8JoQt4+y/kkHvfZ1cZxgl9WKJId1xPj+UadwInj+gMn2Gsv+fLnbrZ4s+6tK2TFQ==}
+    engines: {node: '>=20.8.1'}
+    peerDependencies:
+      semantic-release: '>=24.1.0'
+
   '@semantic-release/github@12.0.6':
     resolution: {integrity: sha512-aYYFkwHW3c6YtHwQF0t0+lAjlU+87NFOZuH2CvWFD0Ylivc7MwhZMiHOJ0FMpIgPpCVib/VUAcOwvrW0KnxQtA==}
     engines: {node: ^22.14.0 || >= 24.10.0}
@@ -1411,6 +1423,10 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
   aggregate-error@5.0.0:
     resolution: {integrity: sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==}
     engines: {node: '>=18'}
@@ -1561,6 +1577,10 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
 
   clean-stack@5.3.0:
     resolution: {integrity: sha512-9ngPTOhYGQqNVSfeJkYXHmF7AGWp4/nN5D/QqNQs3Dvxd1Kk/WpjHfNujKHYUQ/5CoGyOyFNoWSPk5afzP0QVg==}
@@ -2075,6 +2095,10 @@ packages:
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   indent-string@5.0.0:
     resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
@@ -4284,6 +4308,18 @@ snapshots:
 
   '@semantic-release/error@4.0.0': {}
 
+  '@semantic-release/exec@7.1.0(semantic-release@25.0.3(typescript@6.0.2))':
+    dependencies:
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 3.1.0
+      debug: 4.4.3
+      execa: 9.6.1
+      lodash-es: 4.18.1
+      parse-json: 8.3.0
+      semantic-release: 25.0.3(typescript@6.0.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@semantic-release/github@12.0.6(semantic-release@25.0.3(typescript@6.0.2))':
     dependencies:
       '@octokit/core': 7.0.6
@@ -4693,6 +4729,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
   aggregate-error@5.0.0:
     dependencies:
       clean-stack: 5.3.0
@@ -4919,6 +4960,8 @@ snapshots:
       readdirp: 5.0.0
 
   ci-info@4.4.0: {}
+
+  clean-stack@2.2.0: {}
 
   clean-stack@5.3.0:
     dependencies:
@@ -5496,6 +5539,8 @@ snapshots:
       - supports-color
 
   import-meta-resolve@4.2.0: {}
+
+  indent-string@4.0.0: {}
 
   indent-string@5.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ packages:
   - package
 
 catalog:
+  "@semantic-release/exec": ^7
   "@types/node": ^24
   conventional-changelog-conventionalcommits: ^9.3.1
   semantic-release: ^25.0.3


### PR DESCRIPTION
## Summary

`@semantic-release/npm` passes `--userconfig <empty-temp-file>` to `npm publish`, which overrides npm's normal config resolution and prevents the OIDC token exchange from working with trusted publishing.

Fix:
- Use `@semantic-release/npm` only for version bumping (`npmPublish: false`)
- Use `@semantic-release/exec` with `publishCmd: "npm publish package"` to call npm directly
- npm then uses its native OIDC flow via the `.npmrc` created by `actions/setup-node`
- Add `actions/setup-node` with `registry-url` to configure npm for OIDC