### PR TITLE
feat: restore actions/setup-node for npm OIDC registry config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,20 @@ jobs:
 
       - run: vp run @klinking/squircle#build
 
+      - name: Debug npm auth context
+        run: |
+          echo "=== npm config ==="
+          npm config list
+          echo "=== OIDC env vars ==="
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
+          echo "=== .npmrc files ==="
+          cat ~/.npmrc 2>/dev/null || echo "no ~/.npmrc"
+          cat .npmrc 2>/dev/null || echo "no ./.npmrc"
+          cat package/.npmrc 2>/dev/null || echo "no package/.npmrc"
+
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          DEBUG: "semantic-release:*,@semantic-release/npm:*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,4 +34,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_IGNORE_SCRIPTS: true
+          NPM_CONFIG_PROVENANCE: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,6 @@ jobs:
           node-version: "22"
           cache: true
 
-      - uses: actions/setup-node@v4
-        with:
-          registry-url: "https://registry.npmjs.org"
-
       - run: vp install
 
       - run: vp run @klinking/squircle#build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,20 +31,6 @@ jobs:
 
       - run: vp run @klinking/squircle#build
 
-      - name: Debug npm auth context
-        run: |
-          echo "=== npm config ==="
-          npm config list
-          echo "=== OIDC env vars ==="
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL != '' }}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN set: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN != '' }}"
-          echo "=== .npmrc files ==="
-          cat ~/.npmrc 2>/dev/null || echo "no ~/.npmrc"
-          cat .npmrc 2>/dev/null || echo "no ./.npmrc"
-          cat package/.npmrc 2>/dev/null || echo "no package/.npmrc"
-
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          DEBUG: "semantic-release:*,@semantic-release/npm:*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
           node-version: "22"
           cache: true
 
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
       - run: vp install
 
       - run: vp run @klinking/squircle#build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_IGNORE_SCRIPTS: true

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -23,7 +23,7 @@
     [
       "@semantic-release/exec",
       {
-        "publishCmd": "npm publish package"
+        "publishCmd": "npm publish ./package"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
## Summary

Restores `actions/setup-node` with `registry-url` — confirmed it's required for npm's OIDC trusted publishing flow. Without it, npm has no registry config and fails with `ENEEDAUTH`.