### PR TITLE
fix: use Node 24 and remove broken npm self-upgrade step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
@@ -39,10 +39,6 @@ jobs:
 
       - name: Build package
         run: pnpm --filter @klinking/tw-squircle run build
-
-      # Ensure npm 11.5.1 or later for trusted publishing
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Release
         env:


### PR DESCRIPTION
## Summary
- Bump CI node version from 22 to 24 (ships with npm 11+ which has native trusted publishing)
- Remove `npm install -g npm@latest` step that fails on Node 22 with `MODULE_NOT_FOUND: promise-retry`

## Test plan
- [ ] Merge to main and verify the release workflow passes the setup steps
- [ ] Confirm semantic-release runs and publishes via OIDC trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)