### PR TITLE
chore: minimal homepage for initial deploy

### DIFF
--- a/website/src/components/CodeGenerator.tsx
+++ b/website/src/components/CodeGenerator.tsx
@@ -70,41 +70,31 @@ export default function CodeGenerator() {
   const [radiusText, setRadiusText] = useState("60px");
   const [mode, setMode] = useState<CornerMode>("corrected");
 
-  const { cssOutput, twOutput, previewStyle } = useMemo(() => {
+  const { cssOutput, twOutput, previewCss } = useMemo(() => {
     const corners = [`${radius}px`, `${radius}px`, `${radius}px`, `${radius}px`];
     const rv = radiusShorthand(corners);
     const cssK = amount;
 
-    let cssOutput = "";
-    let previewStyle: React.CSSProperties = {};
+    // CSS output always shows corrected mode
+    const corrCorners = corners.map((c) => cssCorrectedRadius(c, cssK));
+    const corrRv = radiusShorthand(corrCorners);
+    const cssOutput =
+      `border-radius: ${rv};\n` +
+      `@supports (corner-shape: superellipse(2)) {\n` +
+      `  border-radius: ${corrRv};\n` +
+      `  corner-shape: superellipse(${cssK});\n` +
+      `}`;
 
+    // Preview CSS varies by mode
+    let previewDecls: string;
     if (mode === "round") {
-      cssOutput = `.your-selector {\n  border-radius: ${rv};\n}`;
-      previewStyle = { borderRadius: rv };
+      previewDecls = `border-radius: ${rv};`;
     } else if (mode === "superellipse") {
-      cssOutput = `.your-selector {\n  border-radius: ${rv};\n  corner-shape: superellipse(${cssK});\n}`;
-      previewStyle = {
-        borderRadius: rv,
-        cornerShape: `superellipse(${cssK})`,
-      } as React.CSSProperties;
+      previewDecls = `border-radius: ${rv};\n  corner-shape: superellipse(${cssK});`;
     } else {
-      // corrected
-      const corrCorners = corners.map((c) => cssCorrectedRadius(c, cssK));
-      const corrRv = radiusShorthand(corrCorners);
-      cssOutput =
-        `/* Fallback for browsers without corner-shape */\n` +
-        `.your-selector {\n  border-radius: ${rv};\n}\n\n` +
-        `@supports (corner-shape: superellipse(2)) {\n` +
-        `  .your-selector {\n` +
-        `    border-radius: ${corrRv};\n` +
-        `    corner-shape: superellipse(${cssK});\n` +
-        `  }\n` +
-        `}`;
-      previewStyle = {
-        borderRadius: corrRv,
-        cornerShape: `superellipse(${cssK})`,
-      } as React.CSSProperties;
+      previewDecls = `border-radius: ${corrRv};\n  corner-shape: superellipse(${cssK});`;
     }
+    const previewCss = `#squircle-preview {\n  ${previewDecls}\n}`;
 
     // Tailwind classes
     const token = closestTwRadius(radius);
@@ -118,7 +108,7 @@ export default function CodeGenerator() {
     }
     const twOutput = classes.join(" ");
 
-    return { cssOutput, twOutput, previewStyle };
+    return { cssOutput, twOutput, previewCss };
   }, [amount, radius, mode]);
 
   function handleAmountTextCommit(value: string) {
@@ -246,7 +236,8 @@ export default function CodeGenerator() {
           {/* Preview */}
           <div className="mb-4">
             <p className="mb-2 text-sm text-zinc-500">Preview</p>
-            <div className="h-40 w-56 bg-indigo-500" style={previewStyle} />
+            <style dangerouslySetInnerHTML={{ __html: previewCss }} />
+            <div id="squircle-preview" className="h-40 w-56 bg-indigo-500" />
           </div>
         </div>
 

--- a/website/src/components/Layout.astro
+++ b/website/src/components/Layout.astro
@@ -15,8 +15,7 @@ const { title } = Astro.props;
     <title>{title}</title>
   </head>
   <body class="min-h-screen bg-zinc-950 text-zinc-100">
-    <div class="mx-auto max-w-5xl px-4 py-12">
-      <header class="mb-8">
+    <header class="mx-auto max-w-5xl px-4 py-12">
         <div>
           <h1 class="text-3xl font-bold">@klinking/squircle</h1>
           <div class="mt-1 flex gap-3">
@@ -39,10 +38,9 @@ const { title } = Astro.props;
           There's just one problem... for the same border-radius, the squircle will
           look less rounded than the circle. That's where this package comes in.
         </p>
-      </header>
-    </div>
+    </header>
 
-    <div class="mx-auto max-w-5xl px-4 pt-8">
+    <div class="mx-auto max-w-5xl px-4">
       <slot />
 
       <footer

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -1,15 +1,7 @@
 ---
 import Layout from "../components/Layout.astro";
-import GuidedExplorer from "../components/GuidedExplorer";
-import CodeGenerator from "../components/CodeGenerator";
 ---
 
-<Layout title="@klinking/squircle — Interactive Demo">
-  <section class="mb-16">
-    <GuidedExplorer client:load />
-  </section>
-
-  <section class="mb-16">
-    <CodeGenerator client:visible />
-  </section>
+<Layout title="@klinking/squircle">
+  <h2 class="mt-8 text-2xl font-semibold text-zinc-300">More coming soon</h2>
 </Layout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -3,5 +3,7 @@ import Layout from "../components/Layout.astro";
 ---
 
 <Layout title="@klinking/squircle">
-  <h2 class="mt-8 text-2xl font-semibold text-zinc-300">More coming soon</h2>
+  <div class="pb-20">
+  <h2 class="pb-4 text-center  text-2xl font-semibold text-zinc-300">More coming soon</h2>
+  <p class="text-center text-zinc-400">Checkout the <a class="text-indigo-400 hover:underline" href="https://github.com/dogmar/squircle">README</a> for more information.</p></div>
 </Layout>


### PR DESCRIPTION
## Summary
- Strips interactive demos (GuidedExplorer, CodeGenerator) from the homepage
- Shows only the intro paragraph and a "More coming soon" placeholder
- Full interactive content will follow in a separate PR

## Test plan
- [ ] Verify the site builds (`vp run website#build`)
- [ ] Confirm only the header text and placeholder are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)