### PR TITLE
Tailwind v3 plugin support

### DIFF
--- a/package/src/tw-plugin-v3.test.ts
+++ b/package/src/tw-plugin-v3.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Placeholder for Tailwind v3 support coverage.
+ *
+ * The plugin's API surface (`plugin.withOptions`, `matchUtilities`,
+ * `{ type: "length" | "number" }`, `theme("borderRadius")`) exists in both
+ * v3 and v4, but the package is currently only declared and tested against
+ * v4 (see `peerDependencies` in package.json).
+ *
+ * Before un-skipping: widen the peerDep to `>=3.0.0`, install v3 alongside
+ * v4 as a dev dependency, document the `require()`-based config.js install
+ * path in the README, and wire this file to compile against v3.
+ *
+ * Tracking: the PR this file was introduced in.
+ */
+import { describe, it } from "vitest";
+
+describe.skip("plugin against Tailwind v3", () => {
+  it.todo("plugin registers via tailwind.config.js { plugins: [require(...)] }");
+  it.todo("matchUtilities { type: 'length' } resolves theme values");
+  it.todo("matchUtilities { type: 'number' } rejects unit-bearing values like [1em]");
+  it.todo("squircle-md emits the same CSS in v3 as in v4");
+  it.todo("prefix option produces correctly namespaced classes");
+  it.todo("amt-var option changes the CSS variable name");
+  it.todo("squircle-t-md (multi-prop) uses intermediate --squircle-r variable");
+  it.todo("squircle-tl-md (single-prop) inlines the correction directly");
+});


### PR DESCRIPTION
## Why this exists

The JS plugin's API surface — `plugin.withOptions`, `matchUtilities`, `theme(\"borderRadius\")`, `{ type: \"length\" | \"number\" }` — is compatible with both Tailwind v3 and v4. But the package currently:

- Declares `\"tailwindcss\": \">=4.0.0\"` in peerDeps ([package/package.json:50](https://github.com/dogmar/squircle/blob/main/package/package.json#L50))
- Only tests against v4 (all tests use the v4 \`compile()\` API in [test-utils.ts](https://github.com/dogmar/squircle/blob/main/package/src/test-utils.ts))
- Documents only the v4 `@plugin \"...\"` CSS install path in the README

So v3 support is *plausibly there* but *not guaranteed and not advertised*.

## What this PR is

A **placeholder** — just a `describe.skip` scaffold at \`package/src/tw-plugin-v3.test.ts\` so the work-to-do is tracked in the repo rather than in a head somewhere. Draft until the checklist below is done.

## Checklist to actually ship v3 support

- [ ] Widen \`peerDependencies.tailwindcss\` to \`\">=3.0.0\"\` in package.json
- [ ] Add Tailwind v3 as a dev dependency (side-by-side with v4) so the test suite can compile against both
- [ ] Figure out the cleanest way to run the same plugin against both v3's config-based setup and v4's \`@plugin\` import — probably a second \`compilePluginV3\` helper in test-utils that uses v3's \`postcss\` pipeline
- [ ] Un-skip \`tw-plugin-v3.test.ts\` and flesh out each \`it.todo\` into a real assertion that mirrors the v4 behavior
- [ ] Document the v3 install path in the README:
  \`\`\`js
  // tailwind.config.js
  const squircle = require(\"@klinking/squircle/tw-plugin\").default
  module.exports = { plugins: [squircle()] }
  \`\`\`
- [ ] Verify the plugin's ESM/CJS exports resolve correctly for v3's config-file require()
- [ ] Remove the nuance note from the README Requirements / FAQ once v3 is genuinely first-class

## Non-goals

- v3 support for the CSS-first \`tw-utils.css\` file. That path uses \`@utility\` and \`--value()\`, which are v4-only and won't be backported.