### PR TITLE
docs: clean up copy/paste source and fix sync workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1056,6 +1056,7 @@ const squircle = stylex.create({
   }),
 });
 export { squircle };
+
 ````
 
 <!-- END:dist/stylex/index.mjs -->

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ We're all excited about `corner-shape: squircle`, but we're in a pickle right no
 ## Contents
 
 <!-- BEGIN:toc -->
-
 - [Requirements](#requirements)
 - [Install & setup](#install--setup)
 - [How the radius correction works](#how-the-radius-correction-works)
@@ -587,7 +586,6 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
 <summary><strong><code>tailwind/utils.css</code></strong> — the Tailwind utilities</summary>
 
 <!-- BEGIN:dist/tailwind/utils.css -->
-
 ```css
 /* ── Squircle utilities ─────────────────────────────────────── */
 /* squircle-amt-[n] sets the superellipse amount (default 2)    */
@@ -747,7 +745,6 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
   }
 }
 ```
-
 <!-- END:dist/tailwind/utils.css -->
 
 </details>
@@ -756,7 +753,6 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
 <summary><strong><code>tailwind/radius.css</code></strong> — the <code>squircle-radius()</code> CSS function</summary>
 
 <!-- BEGIN:dist/tailwind/radius.css -->
-
 ```css
 /* ── squircle-radius() ────────────────────────────────────────
  * Computes the visually-corrected border-radius for use with
@@ -781,7 +777,6 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
   );
 }
 ```
-
 <!-- END:dist/tailwind/radius.css -->
 
 </details>
@@ -834,8 +829,7 @@ export const twMerge = extendTailwindMerge(squircleMergeConfig);
 <summary><strong><code>stylex/index.mjs</code></strong> — the StyleX dynamic-style preset</summary>
 
 <!-- BEGIN:dist/stylex/index.mjs -->
-
-````js
+```js
 import * as stylex from "@stylexjs/stylex";
 /**
  * StyleX squircle utilities — generated from this template by
@@ -1056,9 +1050,7 @@ const squircle = stylex.create({
   }),
 });
 export { squircle };
-
-````
-
+```
 <!-- END:dist/stylex/index.mjs -->
 
 </details>

--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ import { squircle } from "@klinking/squircle/stylex";
 For the footure. Less total CSS than all those tailwind utilities. So beautiful. So utterly currently unusable.
 
 ```css
-@import "@klinking/squircle/tailwind/radius.css";
+@import "@klinking/squircle/radius-function.css";
 
 .card {
   --squircle-amt: 2;
@@ -753,9 +753,9 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
 </details>
 
 <details>
-<summary><strong><code>tailwind/radius.css</code></strong> — the <code>squircle-radius()</code> CSS function</summary>
+<summary><strong><code>radius-function.css</code></strong> — the <code>squircle-radius()</code> CSS function</summary>
 
-<!-- BEGIN:dist/tailwind/radius.css -->
+<!-- BEGIN:dist/radius-function.css -->
 
 ```css
 /* ── squircle-radius() ────────────────────────────────────────
@@ -782,7 +782,7 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
 }
 ```
 
-<!-- END:dist/tailwind/radius.css -->
+<!-- END:dist/radius-function.css -->
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ We're all excited about `corner-shape: squircle`, but we're in a pickle right no
 ## Contents
 
 <!-- BEGIN:toc -->
+
 - [Requirements](#requirements)
 - [Install & setup](#install--setup)
 - [How the radius correction works](#how-the-radius-correction-works)
@@ -586,6 +587,7 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
 <summary><strong><code>tailwind/utils.css</code></strong> — the Tailwind utilities</summary>
 
 <!-- BEGIN:dist/tailwind/utils.css -->
+
 ```css
 /* ── Squircle utilities ─────────────────────────────────────── */
 /* squircle-amt-[n] sets the superellipse amount (default 2)    */
@@ -745,6 +747,7 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
   }
 }
 ```
+
 <!-- END:dist/tailwind/utils.css -->
 
 </details>
@@ -753,6 +756,7 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
 <summary><strong><code>tailwind/radius.css</code></strong> — the <code>squircle-radius()</code> CSS function</summary>
 
 <!-- BEGIN:dist/tailwind/radius.css -->
+
 ```css
 /* ── squircle-radius() ────────────────────────────────────────
  * Computes the visually-corrected border-radius for use with
@@ -777,6 +781,7 @@ If you'd rather not add a dependency, copy the source directly. Click to expand 
   );
 }
 ```
+
 <!-- END:dist/tailwind/radius.css -->
 
 </details>
@@ -829,7 +834,8 @@ export const twMerge = extendTailwindMerge(squircleMergeConfig);
 <summary><strong><code>stylex/index.mjs</code></strong> — the StyleX dynamic-style preset</summary>
 
 <!-- BEGIN:dist/stylex/index.mjs -->
-```js
+
+````js
 import * as stylex from "@stylexjs/stylex";
 /**
  * StyleX squircle utilities — generated from this template by
@@ -1050,7 +1056,8 @@ const squircle = stylex.create({
   }),
 });
 export { squircle };
-```
+````
+
 <!-- END:dist/stylex/index.mjs -->
 
 </details>

--- a/package/package.json
+++ b/package/package.json
@@ -26,7 +26,7 @@
       "import": "./dist/tailwind/index.mjs"
     },
     "./tailwind/utils.css": "./dist/tailwind/utils.css",
-    "./tailwind/radius.css": "./dist/tailwind/radius.css",
+    "./radius-function.css": "./dist/radius-function.css",
     "./panda": {
       "types": "./dist/panda/index.d.mts",
       "import": "./dist/panda/index.mjs"

--- a/package/scripts/generate-squircle-css.ts
+++ b/package/scripts/generate-squircle-css.ts
@@ -64,6 +64,6 @@ writeFileSync(outPath, output);
 console.log(`Generated ${outPath} (skipping fmt)`);
 
 const radiusSrc = join(__dirname, "..", "src", "squircle-radius.css");
-const radiusDest = join(tailwindDir, "radius.css");
+const radiusDest = join(__dirname, "..", "dist", "radius-function.css");
 copyFileSync(radiusSrc, radiusDest);
 console.log(`Copied ${radiusDest}`);

--- a/package/src/squircle-radius.test.ts
+++ b/package/src/squircle-radius.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { correctedRadius } from "./variants";
 
-const distPath = join(import.meta.dirname, "..", "dist", "tailwind", "radius.css");
+const distPath = join(import.meta.dirname, "..", "dist", "radius-function.css");
 
 describe("squircle-radius.css ships", () => {
   it("is copied into dist during build", () => {

--- a/scripts/sync-readme.sh
+++ b/scripts/sync-readme.sh
@@ -88,7 +88,7 @@ sync_toc() {
 }
 
 sync_file "dist/tailwind/utils.css" "css" "package/dist/tailwind/utils.css"
-sync_file "dist/tailwind/radius.css" "css" "package/dist/tailwind/radius.css"
+sync_file "dist/radius-function.css" "css" "package/dist/radius-function.css"
 # tailwind/index.mjs — only the tailwind-merge config is shown (hand-written)
 # Panda preset — bundled output imports internal chunks, not copy/paste-able (#32)
 sync_file "dist/stylex/index.mjs" "js" "package/dist/stylex/index.mjs"


### PR DESCRIPTION
## Summary

- **Clean up copy/paste source section** — remove Panda block (imports internal chunks, tracked in #32), replace Tailwind plugin with just the self-contained tailwind-merge config, strip `//#region`/`//#endregion`/sourcemap lines from synced blocks
- **Format JS code through oxfmt** — `sync-readme.sh` now runs `vp fmt` on JS/TS files before embedding in the README
- **Switch sync-readme workflow to check-only mode** — instead of auto-pushing (which silently skipped required checks due to GITHUB_TOKEN anti-loop), the workflow now fails if the README is out of sync, prompting the dev to run the sync locally
- **Rename `tailwind/radius.css` → `radius-function.css`** — the CSS `@function` has nothing to do with Tailwind; moved to framework-agnostic export path

## Breaking changes

- `@klinking/squircle/tailwind/radius.css` → `@klinking/squircle/radius-function.css`

## Test plan

- [x] `vp run @klinking/squircle#build` succeeds
- [x] `squircle-radius.test.ts` passes (3/3)
- [ ] Rendered README shows clean code blocks on GitHub
- [ ] CI check passes (sync-readme in check-only mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)