### PR TITLE
fix: Update URLs in package.json

### DIFF
--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  sync:
+  sync-readme:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/sync-readme.yml
+++ b/.github/workflows/sync-readme.yml
@@ -3,13 +3,6 @@ name: Sync README code blocks
 on:
   pull_request:
     branches: [main]
-    paths:
-      - package/src/**
-      - package/scripts/generate-squircle-css.ts
-      - package/vite.config.ts
-      - scripts/sync-readme.sh
-      - vite.config.ts
-      - README.md
   workflow_dispatch:
 
 permissions:

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klinking/squircle",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Tailwind CSS v4 squircle (superellipse) corner utilities with visual radius correction",
   "keywords": [
     "border-radius",
@@ -10,11 +10,11 @@
     "tailwind-plugin",
     "tailwindcss"
   ],
-  "homepage": "https://dogmar.github.io/squircle",
+  "homepage": "https://squircle.klink.ing",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/dogmar/squircle.git"
+    "url": "git+https://github.com/klink-ing/squircle.git"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- Update `homepage` and `repository.url` in `package/package.json` to point at the `klink-ing/squircle` repo and `squircle.klink.ing` site
- Reset package `version` to `0.0.0` (pre-release)
- Rename the sync-readme workflow's job from `sync` to `sync-readme` for clarity
- Drop the `paths:` filter on the sync-readme workflow so it runs on every PR to `main` (previously skipped PRs that didn't touch source/script files, letting README drift slip through unchecked)

## Test plan
- [ ] `Sync README code blocks` workflow runs on this PR
- [ ] `CI` and `PR title check` still pass